### PR TITLE
修复 USE_GPU 下的编译

### DIFF
--- a/framework/operators/scale.cpp
+++ b/framework/operators/scale.cpp
@@ -41,7 +41,7 @@ Status ScaleHelper<Ttype, Dtype, Ptype>::InitParam() {
         ScaleParam <Tensor4d<Ttype, Dtype>> param_scale(weights.vector(), bias.vector(), bias_term, axis, num_axes);
         _param_scale = param_scale;
     } else {
-        Tensor4d<Ttype, Dtype>* bias = nullptr;
+        std::vector<Dtype> bias;
         ScaleParam <Tensor4d<Ttype, Dtype>> param_scale(weights.vector(), bias, bias_term, axis, num_axes);
         _param_scale = param_scale;
     }

--- a/framework/operators/scale.cpp
+++ b/framework/operators/scale.cpp
@@ -41,8 +41,7 @@ Status ScaleHelper<Ttype, Dtype, Ptype>::InitParam() {
         ScaleParam <Tensor4d<Ttype, Dtype>> param_scale(weights.vector(), bias.vector(), bias_term, axis, num_axes);
         _param_scale = param_scale;
     } else {
-        std::vector<Dtype> bias;
-        ScaleParam <Tensor4d<Ttype, Dtype>> param_scale(weights.vector(), bias, bias_term, axis, num_axes);
+        ScaleParam <Tensor4d<Ttype, Dtype>> param_scale(weights.vector(), bias_term, axis, num_axes);
         _param_scale = param_scale;
     }
     return Status::OK();

--- a/test/framework/net/chinese_ner_test.cpp
+++ b/test/framework/net/chinese_ner_test.cpp
@@ -17,6 +17,7 @@
 DEFINE_GLOBAL(std::string, model_dir, "");
 DEFINE_GLOBAL(std::string, input_file, "");
 
+
 //#define WITH_MENTION
 
 void getModels(std::string path, std::vector<std::string>& files) {
@@ -114,6 +115,8 @@ int get_batch_data_offset(
     return len;
 }
 
+#ifdef USE_X86_PLACE
+
 TEST(NetTest, chinese_ner_executor) {
     std::vector<std::string> models;
     getModels(GLB_model_dir, models);
@@ -190,6 +193,8 @@ TEST(NetTest, chinese_ner_executor) {
     }
     LOG(INFO)<<"elapse time: "<<timer.get_average_ms()<<" ms";
 }
+
+#endif
 
 int main(int argc, const char** argv) {
     // initial logger

--- a/test/framework/net/chinese_ner_test.cpp
+++ b/test/framework/net/chinese_ner_test.cpp
@@ -17,7 +17,6 @@
 DEFINE_GLOBAL(std::string, model_dir, "");
 DEFINE_GLOBAL(std::string, input_file, "");
 
-
 //#define WITH_MENTION
 
 void getModels(std::string path, std::vector<std::string>& files) {
@@ -116,7 +115,6 @@ int get_batch_data_offset(
 }
 
 #ifdef USE_X86_PLACE
-
 TEST(NetTest, chinese_ner_executor) {
     std::vector<std::string> models;
     getModels(GLB_model_dir, models);
@@ -193,7 +191,6 @@ TEST(NetTest, chinese_ner_executor) {
     }
     LOG(INFO)<<"elapse time: "<<timer.get_average_ms()<<" ms";
 }
-
 #endif
 
 int main(int argc, const char** argv) {


### PR DESCRIPTION
1、在无 bias 参数时使用 Scale 的构造函数重载；
2、用宏定义处理 x86 Graph 在 USE_GPU 不能特化。