### PR TITLE
fix specific cudnn include and library path

### DIFF
--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -81,11 +81,15 @@ macro(anakin_find_cudnn)
   	find_path(CUDNN_INCLUDE_DIR cudnn.h PATHS ${CUDNN_ROOT} ${CUDNN_ROOT}/include
 						  $ENV{CUDNN_ROOT} 
 						  $ENV{CUDNN_ROOT}/include
+						  $ENV{CUDNN_INCLUDE_DIR}
 						  ${ANAKIN_ROOT}/third-party/cudnn/include NO_DEFAULT_PATH)
+    message(STATUS "cudnn include header is ${CUDNN_INCLUDE_DIR}/cudnn.h")
     if(BUILD_SHARED)
         find_library(CUDNN_LIBRARY NAMES libcudnn.so 
                                PATHS ${CUDNN_INCLUDE_DIR}/../lib64/ ${CUDNN_INCLUDE_DIR}/
+						                   $ENV{CUDNN_LIBRARY}
                                DOC "library path for cudnn.") 
+        message(STATUS "cudnn library is ${CUDNN_LIBRARY}/libcudnn.so")
     else()
         find_library(CUDNN_LIBRARY NAMES libcudnn_static.a
                                PATHS ${CUDNN_INCLUDE_DIR}/../lib64/


### PR DESCRIPTION
fix https://github.com/PaddlePaddle/Paddle/pull/12693#issue-208200488
由于paddle docker image里的cudnn include和library路径，用cuda.cmake中的查找规则找不到，因此增加两个环境变量来解决这个问题。