### PR TITLE
remove a lot of warning

### DIFF
--- a/cmake/compiler_options.cmake
+++ b/cmake/compiler_options.cmake
@@ -41,6 +41,8 @@ anakin_add_compile_option(-Wshadow)
 anakin_add_compile_option(-fpermissive)
 anakin_add_compile_option(-Wsign-promo)
 anakin_add_compile_option(-fdiagnostics-show-option)
+anakin_add_compile_option(-Wno-missing-field-initializers)
+anakin_add_compile_option(-Wno-extra)
 
 if(ENABLE_NOISY_WARNINGS)
 	anakin_add_compile_option(-Wcast-align)


### PR DESCRIPTION
There are a lot of warnings in Paddle TeamCity log.

```
[05:18:30]	/paddle/build/third_party/anakin/src/extern_anakin/saber/funcs/impl/x86/jit_avx512_conv_act.cpp:280:16:   required from here
[05:18:30]	/paddle/build/third_party/anakin/src/extern_anakin/saber/funcs/impl/x86/jit_avx512_conv_act.cpp:183:40: warning: missing initializer for member 'anakin::saber::jit::jit_conv_call_t::dst' [-Wmissing-field-initializers]
[05:18:30]	         jit_conv_call_t par_conv = { 0 };
```
using `anakin_add_compile_option(-Wno-missing-field-initializers)` can avoid this. 
```
[05:19:11]	/paddle/build/third_party/install/protobuf/include/google/protobuf/map.h:1292:32: warning: enumeral and non-enumeral type in conditional expression [-Wextra]
[05:19:11]	       return n < kMinTableSize ? kMinTableSize : n;
```
using `anakin_add_compile_option(-Wno-extra)` can avoid this.
