### PR TITLE
fix issue 428

### DIFF
--- a/cmake/ios/ios.toolchain.cmake
+++ b/cmake/ios/ios.toolchain.cmake
@@ -47,8 +47,10 @@ endif (CMAKE_UNAME)
 
 # Force the compilers to gcc for iOS
 include (CMakeForceCompiler)
-CMAKE_FORCE_C_COMPILER (/usr/bin/clang Apple)
-CMAKE_FORCE_CXX_COMPILER (/usr/bin/clang++ Apple)
+set(CMAKE_C_COMPILER /usr/bin/clang)
+set(CMAKE_CXX_COMPILER /usr/bin/clang++)
+#CMAKE_FORCE_C_COMPILER (/usr/bin/clang Apple)
+#CMAKE_FORCE_CXX_COMPILER (/usr/bin/clang++ Apple)
 set(CMAKE_AR ar CACHE FILEPATH "" FORCE)
 
 # Skip the platform compiler checks for cross compiling


### PR DESCRIPTION
fix iOS cmake toolchain build failed on some mac,  fix issue 428