### PR TITLE
Abstract away exposed openmp dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,6 @@ anakin_option(USE_GFLAGS "Build Google gflags components." NO)
 anakin_option(USE_MKL "Use mkl libs." NO if USE_X86_PLACE)
 anakin_option(USE_MKLML "Use MKLML libs." YES if USE_X86_PLACE)
 anakin_option(USE_XBYAK "Use XBYAK libs." YES if USE_X86_PLACE)
-anakin_option(USE_OPENMP "Use Openmp when in android environment." YES if TARGET_ANDROID)
 
 # build components
 anakin_option(BUILD_WITH_UNIT_TEST "Build anakin unit test components." YES)

--- a/framework/c_api/anakin_runner.cpp
+++ b/framework/c_api/anakin_runner.cpp
@@ -333,11 +333,11 @@ char* get_ak_cpu_arch_string() {
 
 #ifdef USE_X86_PLACE
 
-#include "omp.h"
+#include "anakin_thread.h"
 #include "mkl_service.h"
 void set_ak_cpu_parallel() {
-    omp_set_dynamic(0);
-    omp_set_num_threads(1);
+    anakin_set_dynamic(0);
+    anakin_set_num_threads(1);
     mkl_set_num_threads(1);
 }
 #endif

--- a/framework/lite/utils.h
+++ b/framework/lite/utils.h
@@ -19,6 +19,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "framework/core/parameter.h"
+
 namespace anakin {
 
 namespace lite {

--- a/saber/funcs/impl/x86/anakin_thread.h
+++ b/saber/funcs/impl/x86/anakin_thread.h
@@ -32,10 +32,12 @@
 #define ANAKIN_THR_SYNC 1
 inline int anakin_get_max_threads() { return 1; }
 inline int anakin_get_num_threads() { return 1; }
+inline void anakin_set_num_threads(int val) {}
 inline int anakin_get_thread_num() { return 0; }
 inline int anakin_in_parallel() { return 0; }
 inline void anakin_thr_barrier() {}
 inline void anakin_set_nested(int val) {}
+inline void anakin_set_dynamic(int val) {}
 
 #elif ANAKIN_THR == ANAKIN_THR_OMP
 #include <omp.h>
@@ -43,12 +45,14 @@ inline void anakin_set_nested(int val) {}
 
 inline int anakin_get_max_threads() { return omp_get_max_threads(); }
 inline int anakin_get_num_threads() { return omp_get_num_threads(); }
+inline void anakin_set_num_threads(int val) { omp_set_num_threads(val); }
 inline int anakin_get_thread_num() { return omp_get_thread_num(); }
 inline int anakin_in_parallel() { return omp_in_parallel(); }
 inline void anakin_thr_barrier() {
 #   pragma omp barrier
 }
 inline void anakin_set_nested(int val) { omp_set_nested(val); }
+inline void anakin_set_dynamic(int val) { omp_set_dynamic(val); }
 
 #elif ANAKIN_THR == ANAKIN_THR_TBB
 #include "tbb/parallel_for.h"

--- a/saber/funcs/impl/x86/anakin_thread.h
+++ b/saber/funcs/impl/x86/anakin_thread.h
@@ -35,6 +35,7 @@ inline int anakin_get_num_threads() { return 1; }
 inline int anakin_get_thread_num() { return 0; }
 inline int anakin_in_parallel() { return 0; }
 inline void anakin_thr_barrier() {}
+inline void anakin_set_nested(int val) {}
 
 #elif ANAKIN_THR == ANAKIN_THR_OMP
 #include <omp.h>
@@ -47,6 +48,7 @@ inline int anakin_in_parallel() { return omp_in_parallel(); }
 inline void anakin_thr_barrier() {
 #   pragma omp barrier
 }
+inline void anakin_set_nested(int val) { omp_set_nested(val); }
 
 #elif ANAKIN_THR == ANAKIN_THR_TBB
 #include "tbb/parallel_for.h"
@@ -73,26 +75,6 @@ namespace anakin {
 namespace saber {
 
 inline bool anakin_thr_syncable() { return ANAKIN_THR_SYNC == 1; }
-
-template <typename T, typename U>
-inline void balance211(T n, U team, U tid, T &n_start, T &n_end) {
-    T n_min = 1;
-    T &n_my = n_end;
-    if (team <= 1 || n == 0) {
-        n_start = 0;
-        n_my = n;
-    } else if (n_min == 1) {
-        // team = T1 + T2
-        // n = T1*n1 + T2*n2  (n1 - n2 = 1)
-        T n1 = utils::div_up(n, (T)team);
-        T n2 = n1 - 1;
-        T T1 = n - n2 * (T)team;
-        n_my = (T)tid < T1 ? n1 : n2;
-        n_start = (T)tid <= T1 ? tid * n1 : T1 * n1 + ((T)tid - T1) * n2;
-    }
-
-    n_end += n_start;
-}
 
 } // namespace saber
 } // namespace anakin

--- a/saber/funcs/impl/x86/gemm_u8s8s32x_conv.cpp
+++ b/saber/funcs/impl/x86/gemm_u8s8s32x_conv.cpp
@@ -103,8 +103,8 @@ SaberStatus GemmU8S8S32XConv::dispatch(const std::vector<Tensor<X86>*> &inputs,
 
         int n{0}, g{0};
         size_t start = 0, end = 0;
-        utils::balance211 (work_amount, nthr, ithr, start, end);
-        utils::nd_iterator_init (start, n, jcp.mb, g, jcp.ngroups);
+        balance211 (work_amount, nthr, ithr, start, end);
+        nd_iterator_init (start, n, jcp.mb, g, jcp.ngroups);
 
         for (size_t iwork = start; iwork < end; ++iwork) {
             const unsigned char *src = ptr_src + n * src_mb_stride + g * src_g_stride;
@@ -144,7 +144,7 @@ SaberStatus GemmU8S8S32XConv::dispatch(const std::vector<Tensor<X86>*> &inputs,
                 }
             }
 
-            utils::nd_iterator_step (n, jcp.mb, g, jcp.ngroups);
+            nd_iterator_step (n, jcp.mb, g, jcp.ngroups);
         }
     });
 
@@ -212,7 +212,7 @@ SaberStatus GemmU8S8S32XConv::init_conf(jit_conv_conf_t &jcp,
         return SaberUnImplError;
     }
 
-    jcp.nthr = omp_get_max_threads();
+    jcp.nthr = anakin_get_max_threads();
     if (!(jcp.ic == 1 &&
           jcp.oc == 1 &&
           jcp.ngroups != 1) &&
@@ -255,7 +255,7 @@ SaberStatus GemmU8S8S32XConv::check_conf(const jit_conv_conf_t &jcp,
 SaberStatus GemmU8S8S32XConv::im2col_u8(const jit_conv_conf_t &jcp,
                                         const unsigned char* im,
                                         unsigned char* col) {
-    int num_thr = (jcp.mb != 1) ? omp_get_max_threads() : 1;
+    int num_thr = (jcp.mb != 1) ? anakin_get_max_threads() : 1;
     MAYBE_UNUSED(num_thr);
     #pragma omp parallel for collapse(2) num_threads(num_thr)
     for (int oh = 0; oh < jcp.oh; ++oh) {

--- a/saber/funcs/impl/x86/kernel/jit_avx2_conv.cpp
+++ b/saber/funcs/impl/x86/kernel/jit_avx2_conv.cpp
@@ -203,7 +203,7 @@ SaberStatus JitAvx2Conv<AK_FLOAT>::dispatch(
 
     auto ker = [&](const int ithr, const int nthr) {
         size_t start{0}, end{0};
-        utils::balance211(work_amount, nthr, ithr, start, end);
+        balance211(work_amount, nthr, ithr, start, end);
 
         int icbb = 0;
         while (icbb < jcp.nb_ic) {
@@ -214,7 +214,7 @@ SaberStatus JitAvx2Conv<AK_FLOAT>::dispatch(
             }
 
             size_t n{0}, g{0}, ocbb{0}, oh{0};
-            utils::nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ocbb, ocb_work, oh, jcp.oh);
+            nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ocbb, ocb_work, oh, jcp.oh);
             for (size_t iwork = start; iwork < end; ++iwork) {
                 int ocb = ocbb * jcp.nb_oc_blocking;
                 int ocb_num = jcp.nb_oc_blocking;
@@ -270,8 +270,7 @@ SaberStatus JitAvx2Conv<AK_FLOAT>::dispatch(
 
                     kernel->jit_ker(&par_conv);
                 }
-                utils::nd_iterator_step(n, jcp.mb, g, jcp.ngroups, ocbb, ocb_work,
-                                        oh, jcp.oh);
+                nd_iterator_step(n, jcp.mb, g, jcp.ngroups, ocbb, ocb_work, oh, jcp.oh);
             }
             icbb += icb_step;
         }
@@ -279,7 +278,7 @@ SaberStatus JitAvx2Conv<AK_FLOAT>::dispatch(
 
 #pragma omp parallel
     {
-        ker(omp_get_thread_num(), omp_get_num_threads());
+        ker(anakin_get_thread_num(), anakin_get_num_threads());
     }
 
     return SaberSuccess;

--- a/saber/funcs/impl/x86/kernel/jit_avx512_conv.cpp
+++ b/saber/funcs/impl/x86/kernel/jit_avx512_conv.cpp
@@ -242,11 +242,11 @@ SaberStatus JitAvx512Conv<AK_FLOAT>::dispatch(
 
 #pragma omp parallel
     {
-        int ithr = omp_get_thread_num(), nthr = omp_get_num_threads();
+        int ithr = anakin_get_thread_num(), nthr = anakin_get_num_threads();
         int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
         int start, end, start_copy;
         int work_amount = jcp.mb * jcp.ngroups * oc_chunks * jcp.oh;
-        utils::balance211(work_amount, nthr, ithr, start, end);
+        balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
         auto par_conv = jit_conv_call_t();
@@ -271,10 +271,10 @@ SaberStatus JitAvx512Conv<AK_FLOAT>::dispatch(
             start = start_copy;
             int n{0}, g{0}, occ{0}, oh_s{0};
             if (jcp.loop_order == conv_loop_order_t::loop_cgn) {
-                utils::nd_iterator_init(start, occ, oc_chunks, g, jcp.ngroups, n, jcp.mb, oh_s, jcp.oh);
+                nd_iterator_init(start, occ, oc_chunks, g, jcp.ngroups, n, jcp.mb, oh_s, jcp.oh);
             }
             else if (jcp.loop_order == conv_loop_order_t::loop_gnc) {
-                utils::nd_iterator_init(start, g, jcp.ngroups, n, jcp.mb, occ, oc_chunks, oh_s, jcp.oh);
+                nd_iterator_init(start, g, jcp.ngroups, n, jcp.mb, occ, oc_chunks, oh_s, jcp.oh);
             }
 
             while (start < end) {
@@ -335,10 +335,10 @@ SaberStatus JitAvx512Conv<AK_FLOAT>::dispatch(
                 }
 
                 if (jcp.loop_order == conv_loop_order_t::loop_cgn) {
-                    utils::nd_iterator_jump(start, end,
-                                            occ, oc_chunks, g, jcp.ngroups, n, jcp.mb, oh_s, jcp.oh);
+                    nd_iterator_jump(start, end,
+                                     occ, oc_chunks, g, jcp.ngroups, n, jcp.mb, oh_s, jcp.oh);
                 } else if (jcp.loop_order == conv_loop_order_t::loop_gnc) {
-                    utils::nd_iterator_jump(start, end, g, jcp.ngroups, n, jcp.mb, occ, oc_chunks, oh_s, jcp.oh);
+                    nd_iterator_jump(start, end, g, jcp.ngroups, n, jcp.mb, occ, oc_chunks, oh_s, jcp.oh);
                 }
             }
         }

--- a/saber/funcs/impl/x86/kernel/jit_avx512_core_u8s8s32x_conv.cpp
+++ b/saber/funcs/impl/x86/kernel/jit_avx512_core_u8s8s32x_conv.cpp
@@ -119,11 +119,11 @@ SaberStatus JitAvx512U8S8S32XConv::dispatch(const std::vector<Tensor<X86>*> &inp
 
         int n{0}, gb{0}, occ{0}, oh_s{0};
         if (jcp.loop_order == loop_cgn) {
-            utils::nd_iterator_init(start, occ, oc_chunks, gb, nb_groups, n, jcp.mb, oh_s, jcp.oh);
+            nd_iterator_init(start, occ, oc_chunks, gb, nb_groups, n, jcp.mb, oh_s, jcp.oh);
         } else if (jcp.loop_order == loop_gnc) {
-            utils::nd_iterator_init(start, gb, nb_groups, n, jcp.mb, occ, oc_chunks, oh_s, jcp.oh);
+            nd_iterator_init(start, gb, nb_groups, n, jcp.mb, occ, oc_chunks, oh_s, jcp.oh);
         } else if (jcp.loop_order == loop_ngc) {
-            utils::nd_iterator_init(start, n, jcp.mb, gb, nb_groups, occ, oc_chunks, oh_s, jcp.oh);
+            nd_iterator_init(start, n, jcp.mb, gb, nb_groups, occ, oc_chunks, oh_s, jcp.oh);
         } else {
             assert(!"unsupported loop order");
         }
@@ -161,8 +161,7 @@ SaberStatus JitAvx512U8S8S32XConv::dispatch(const std::vector<Tensor<X86>*> &inp
                 int i_t_overflow = utils::div_up(utils::max(0, -ij), dilate_h);
                 int i_b_overflow = utils::div_up(utils::max(0, ij - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
                                                  dilate_h);
-                int kh_padding = utils::max(0,
-                                            jcp.kh - i_t_overflow - i_b_overflow);
+                int kh_padding = utils::max(0, jcp.kh - i_t_overflow - i_b_overflow);
 
                 p.src = src_w + i_t_overflow * dilate_h * src_h_stride;
                 p.dst = dst_w;
@@ -178,14 +177,14 @@ SaberStatus JitAvx512U8S8S32XConv::dispatch(const std::vector<Tensor<X86>*> &inp
             }
 
             if (jcp.loop_order == loop_cgn) {
-                utils::nd_iterator_jump(start, end, occ, oc_chunks, gb, nb_groups, n,
-                                        jcp.mb, oh_s, jcp.oh);
+                nd_iterator_jump(start, end, occ, oc_chunks, gb, nb_groups, n,
+                                 jcp.mb, oh_s, jcp.oh);
             } else if (jcp.loop_order == loop_gnc) {
-                utils::nd_iterator_jump(start, end, gb, nb_groups, n, jcp.mb, occ,
-                                        oc_chunks, oh_s, jcp.oh);
+                nd_iterator_jump(start, end, gb, nb_groups, n, jcp.mb, occ,
+                                 oc_chunks, oh_s, jcp.oh);
             } else if (jcp.loop_order == loop_ngc) {
-                utils::nd_iterator_jump(start, end, n, jcp.mb, gb, nb_groups, occ,
-                                        oc_chunks, oh_s, jcp.oh);
+                nd_iterator_jump(start, end, n, jcp.mb, gb, nb_groups, occ,
+                                 oc_chunks, oh_s, jcp.oh);
             } else {
                 assert(!"unsupported loop order");
             }
@@ -268,7 +267,7 @@ SaberStatus JitAvx512U8S8S32XConv::init_conf(jit_conv_conf_t &jcp,
         return SaberUnImplError;
     }
 
-    const int nthreads = omp_get_max_threads();
+    const int nthreads = anakin_get_max_threads();
     ws_per_thread_ = jcp.oh * jcp.ow * jcp.oc;
     ws_ = (int *)zmalloc(nthreads * ws_per_thread_ * sizeof(int), 4096);
     if (!ws_) {

--- a/saber/funcs/impl/x86/kernel/jit_avx512_rtus_driver.h
+++ b/saber/funcs/impl/x86/kernel/jit_avx512_rtus_driver.h
@@ -184,7 +184,7 @@ inline void init_rtus_driver(rtus_driver_t **p_rtus_driver,
                              conv_1x1_desc &conv_d,
                              size_t &ws_per_thread,
                              Dtype **p_scratch) {
-    const int max_threads = omp_get_max_threads();
+    const int max_threads = anakin_get_max_threads();
     size_t factor = 0;
 
     factor = jcp.nb_reduce;

--- a/saber/funcs/impl/x86/kernel/jit_generator.h
+++ b/saber/funcs/impl/x86/kernel/jit_generator.h
@@ -12,6 +12,7 @@
 #include "xbyak/xbyak.h"
 #include "xbyak/xbyak_util.h"
 #include "x86_utils.h"
+#include "anakin_thread.h"
 
 #define DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_name)                      \
   const char *name() const override { return #jit_name; } \
@@ -117,7 +118,7 @@ inline unsigned int get_cache_size(int level, bool per_core = true) {
     const int L1_cache_per_core = 32000;
     const int L2_cache_per_core = 512000;
     const int L3_cache_per_core = 1024000;
-    int num_cores = per_core ? 1 : omp_get_max_threads();
+    int num_cores = per_core ? 1 : anakin_get_max_threads();
     switch (l) {
       case (0):
         return L1_cache_per_core * num_cores;

--- a/saber/funcs/impl/x86/kernel/jit_uni_1x1_conv_utils.h
+++ b/saber/funcs/impl/x86/kernel/jit_uni_1x1_conv_utils.h
@@ -44,38 +44,6 @@ inline int best_divider(int value, int min_divider, int max_divider,
     return x_divider;
 }
 
-
-template <typename T, typename U, typename V>
-inline U this_block_size(const T offset, const U max, const V block_size) {
-    assert(offset < max);
-    const T block_boundary = offset + block_size;
-    if (block_boundary > max)
-        return max - offset;
-    else
-        return block_size;
-}
-
-template<typename T>
-inline T nd_iterator_init(T start) { return start; }
-
-template<typename T, typename U, typename W, typename... Args>
-inline T nd_iterator_init(T start, U &x, const W &X, Args &&... tuple) {
-    start = nd_iterator_init(start, utils::forward<Args>(tuple)...);
-    x = start % X;
-    return start / X;
-}
-
-inline bool nd_iterator_step() { return true; }
-
-template<typename U, typename W, typename... Args>
-inline bool nd_iterator_step(U &x, const W &X, Args &&... tuple) {
-    if (nd_iterator_step(utils::forward<Args>(tuple)...)) {
-        x = (x + 1) % X;
-        return x == 0;
-    }
-    return false;
-}
-
 } // namepsace jit
 
 #define JIT_TENSOR_MAX_DIMS 12

--- a/saber/funcs/impl/x86/kernel/jit_uni_dwconv.cpp
+++ b/saber/funcs/impl/x86/kernel/jit_uni_dwconv.cpp
@@ -239,10 +239,10 @@ SaberStatus JitUniDWConv<AK_FLOAT>::dispatch(
 
     auto ker = [&](const int ithr, const int nthr) {
         size_t start{0}, end{0};
-        utils::balance211(work_amount, nthr, ithr, start, end);
+        balance211(work_amount, nthr, ithr, start, end);
 
         size_t n{0}, chb{0}, oh{0};
-        utils::nd_iterator_init(start, n, MB, chb, chb_work, oh, jcp.oh);
+        nd_iterator_init(start, n, MB, chb, chb_work, oh, jcp.oh);
         for (size_t iwork = start; iwork < end; ++iwork) {
             int ch = chb * jcp.nb_ch_blocking;
             int ch_num = jcp.nb_ch_blocking;
@@ -288,13 +288,13 @@ SaberStatus JitUniDWConv<AK_FLOAT>::dispatch(
                 kernel->jit_ker(&par_conv);
             }
 
-            utils::nd_iterator_step(n, MB, chb, chb_work, oh, jcp.oh);
+            nd_iterator_step(n, MB, chb, chb_work, oh, jcp.oh);
         }
     };
 
 #pragma omp parallel
     {
-        ker(omp_get_thread_num(), omp_get_num_threads());
+        ker(anakin_get_thread_num(), anakin_get_num_threads());
     }
 
     return SaberSuccess;

--- a/saber/funcs/impl/x86/saber_crf_decoding.cpp
+++ b/saber/funcs/impl/x86/saber_crf_decoding.cpp
@@ -2,11 +2,11 @@
 #include "saber/funcs/impl/x86/saber_crf_decoding.h"
 #include "saber/saber_funcs_param.h"
 #include "saber/funcs/impl/x86/x86_utils.h"
+#include "saber/funcs/impl/x86/anakin_thread.h"
 #include <cstring>
 #include <limits>
 #include <cmath>
 #include <immintrin.h>
-#include "omp.h"
 
 namespace anakin {
 namespace saber {
@@ -213,7 +213,7 @@ SaberStatus SaberCrfDecoding<X86, OpDtype>::dispatch(
 #endif
     OpDataType *decoded_path = (OpDataType*) outputs[0]->mutable_data();
     int seq_num = seq_offset[0].size() - 1;
-    int nthreads = omp_get_max_threads();
+    int nthreads = anakin_get_max_threads();
 
     if (nthreads > seq_num) {
         nthreads = seq_num;

--- a/saber/funcs/impl/x86/sequence2batch.h
+++ b/saber/funcs/impl/x86/sequence2batch.h
@@ -6,6 +6,7 @@
 #include "saber/core/tensor.h"
 
 #include "saber/funcs/impl/x86/x86_utils.h"
+#include "saber/funcs/impl/x86/anakin_thread.h"
 
 namespace anakin {
 namespace saber {
@@ -362,7 +363,7 @@ protected:
     std::vector<int> batchStartPositions_;
     std::vector<int> seq2BatchIdx_;
     size_t numBatch_;
-    int thread_num = omp_get_max_threads();
+    int thread_num = anakin_get_max_threads();
 };
 }  // namespace math
 }  // namespace saber

--- a/saber/funcs/impl/x86/vender_gru.cpp
+++ b/saber/funcs/impl/x86/vender_gru.cpp
@@ -17,7 +17,7 @@ SaberStatus VenderGru<X86, OpDtype>::init(
                 std::vector<OpTensor*>& outputs,
 GruParam<X86>& param, Context<X86>& ctx) {
     this->_ctx = &ctx;
-    this->max_thread_num_ = omp_get_max_threads();
+    this->max_thread_num_ = anakin_get_max_threads();
     hidden_size_ = outputs[0]->channel();
     word_size_ = inputs[0]->channel();
 

--- a/saber/funcs/impl/x86/vender_lstm.cpp
+++ b/saber/funcs/impl/x86/vender_lstm.cpp
@@ -31,7 +31,7 @@ SaberStatus VenderLstm<X86, AK_FLOAT>::init(
     LstmParam<X86>& param, Context<X86>& ctx) {
     const char* ret = std::getenv("OMP_NUM_THREADS");
     this->_ctx = &ctx;
-    this->max_thread_num_ = ret ? atoi(ret) : omp_get_max_threads();
+    this->max_thread_num_ = ret ? atoi(ret) : anakin_get_max_threads();
     int layer_num_ = param.num_layers;
     int direc_num_ = param.num_direction;
     hidden_size_ = outputs[0]->channel() / direc_num_;
@@ -630,7 +630,7 @@ SaberStatus VenderLstm<X86, AK_FLOAT>::dispatch(
     int i_offset = 1;
     int c_offset = 2;
     int o_offset = 3;
-    omp_set_nested(1);
+    anakin_set_nested(1);
     mkl_set_dynamic(0);
 
     if (batch_size_ == 1) {


### PR DESCRIPTION
Some code has explicit dependencies on `omp_*` functions. Replace them with anakin abstractions defined in [saber/funcs/impl/x86/anakin_thread.h](https://github.com/PaddlePaddle/Anakin/blob/master/saber/funcs/impl/x86/anakin_thread.h).